### PR TITLE
Fix task metrics logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ async fn main() {
     // construct a TaskMonitor
     let monitor = tokio_metrics_collector::TaskMonitor::new();
     // add this monitor to task collector with label 'simple_task'
+    // NOTE: duplicate labels in multiple monitors cause incorrect data aggregation.
+    // It is recommended to use unique labels for each monitor and
+    // instrument multiple tasks by the `instrument` function.
     task_collector.add("simple_task", monitor.clone());
 
     // spawn a background task and instrument
@@ -97,35 +100,35 @@ rustdocflags = ["--cfg", "tokio_unstable"]
 ```
 
 - **[`workers_count`]**  
-  The number of worker threads used by the runtime.
+  [`Gauge`] The number of worker threads used by the runtime.
 - **[`total_park_count`]**  
-  The number of times worker threads parked.
+  [`Counter] The number of times worker threads parked.
 - **[`total_noop_count`]**  
-  The number of times worker threads unparked but performed no work before parking again.
+  [`Counter] The number of times worker threads unparked but performed no work before parking again.
 - **[`total_steal_count`]**  
-  The number of tasks worker threads stole from another worker thread.
+  [`Counter] The number of tasks worker threads stole from another worker thread.
 - **[`total_steal_operations`]**  
-  The number of times worker threads stole tasks from another worker thread.
+  [`Counter] The number of times worker threads stole tasks from another worker thread.
 - **[`num_remote_schedules`]**  
-  The number of tasks scheduled from outside of the runtime.
+  [`Counter] The number of tasks scheduled from outside of the runtime.
 - **[`total_local_schedule_count`]**  
-  The number of tasks scheduled from worker threads.
+  [`Counter] The number of tasks scheduled from worker threads.
 - **[`total_overflow_count`]**  
-  The number of times worker threads saturated their local queues.
+  [`Counter] The number of times worker threads saturated their local queues.
 - **[`total_polls_count`]**  
-  The number of tasks that have been polled across all worker threads.
+  [`Counter] The number of tasks that have been polled across all worker threads.
 - **[`total_busy_duration`]**  
-  The amount of time worker threads were busy.
+  [`Counter] The amount of time worker threads were busy.
 - **[`injection_queue_depth`]**  
-  The number of tasks currently scheduled in the runtime's injection queue.
+  [`Gauge`] The number of tasks currently scheduled in the runtime's injection queue.
 - **[`total_local_queue_depth`]**  
-  The total number of tasks currently scheduled in workers' local queues.
+  [`Gauge`] The total number of tasks currently scheduled in workers' local queues.
 - **[`elapsed`]**  
-  Total amount of time elapsed since observing runtime metrics.
+  [`Counter`] Total amount of time elapsed since observing runtime metrics.
 - **[`budget_forced_yield_count`]**  
-  The number of times that a task was forced to yield because it exhausted its budget.
+  [`Counter`] The number of times that a task was forced to yield because it exhausted its budget.
 - **[`io_driver_ready_count`]**  
-  The number of ready events received from the I/O driver.
+  [`Counter`] The number of ready events received from the I/O driver.
 
 [`workers_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
 [`total_park_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
@@ -148,41 +151,41 @@ rustdocflags = ["--cfg", "tokio_unstable"]
 ## Task Metrics
 
 - **[`instrumented_count`]**  
-  The number of tasks instrumented.
+  [`Gauge`] The number of tasks instrumented in the interval.
 - **[`dropped_count`]**  
-  The number of tasks dropped.
+  [`Gauge] The number of tasks dropped in the interval.
 - **[`first_poll_count`]**  
-  The number of tasks polled for the first time.
+  [`Gauge`] The number of tasks polled for the first time in the interval.
 - **[`total_first_poll_delay`]**  
-  The total duration elapsed between the instant tasks are instrumented, and the instant they are first polled.
+  [`Counter`] The total duration elapsed between the instant tasks are instrumented, and the instant they are first polled.
 - **[`total_idled_count`]**  
-  The total number of times that tasks idled, waiting to be awoken.
+  [`Counter`] The total number of times that tasks idled, waiting to be awoken.
 - **[`total_idle_duration`]**  
-  The total duration that tasks idled.
+  [`Counter`] The total duration that tasks idled.
 - **[`total_scheduled_count`]**  
-  The total number of times that tasks were awoken (and then, presumably, scheduled for execution).
+  [`Counter`] The total number of times that tasks were awoken (and then, presumably, scheduled for execution).
 - **[`total_scheduled_duration`]**  
-  The total duration that tasks spent waiting to be polled after awakening.
+  [`Counter`] The total duration that tasks spent waiting to be polled after awakening.
 - **[`total_poll_count`]**  
-  The total number of times that tasks were polled.
+  [`Counter`] The total number of times that tasks were polled.
 - **[`total_poll_duration`]**  
-  The total duration elapsed during polls.
+  [`Counter`] The total duration elapsed during polls.
 - **[`total_fast_poll_count`]**  
-  The total number of times that polling tasks completed swiftly.
+  [`Counter`] The total number of times that polling tasks completed swiftly.
 - **[`total_fast_poll_duration`]**  
-  The total duration of fast polls.
+  [`Counter`] The total duration of fast polls.
 - **[`total_slow_poll_count`]**  
-  The total number of times that polling tasks completed slowly.
+  [`Counter`] The total number of times that polling tasks completed slowly.
 - **[`total_slow_poll_duration`]**  
-  The total duration of slow polls.
+  [`Counter`] The total duration of slow polls.
 - **[`total_short_delay_count`]**  
-  The total count of short scheduling delays.
+  [`Counter`] The total count of short scheduling delays.
 - **[`total_short_delay_duration`]**  
-  The total duration of short scheduling delays.
+  [`Counter`] The total duration of short scheduling delays.
 - **[`total_long_delay_count`]**  
-  The total count of long scheduling delays.
+  [`Counter`] The total count of long scheduling delays.
 - **[`total_long_delay_duration`]**  
-  The total duration of long scheduling delays.
+  [`Counter`] The total duration of long scheduling delays.
 
 [`instrumented_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
 [`dropped_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count

--- a/README.md
+++ b/README.md
@@ -99,36 +99,36 @@ rustflags = ["--cfg", "tokio_unstable"]
 rustdocflags = ["--cfg", "tokio_unstable"]
 ```
 
-- **[`workers_count`]**  
-  [`Gauge`] The number of worker threads used by the runtime.
-- **[`total_park_count`]**  
-  [`Counter] The number of times worker threads parked.
-- **[`total_noop_count`]**  
-  [`Counter] The number of times worker threads unparked but performed no work before parking again.
-- **[`total_steal_count`]**  
-  [`Counter] The number of tasks worker threads stole from another worker thread.
-- **[`total_steal_operations`]**  
-  [`Counter] The number of times worker threads stole tasks from another worker thread.
-- **[`num_remote_schedules`]**  
-  [`Counter] The number of tasks scheduled from outside of the runtime.
-- **[`total_local_schedule_count`]**  
-  [`Counter] The number of tasks scheduled from worker threads.
-- **[`total_overflow_count`]**  
-  [`Counter] The number of times worker threads saturated their local queues.
-- **[`total_polls_count`]**  
-  [`Counter] The number of tasks that have been polled across all worker threads.
-- **[`total_busy_duration`]**  
-  [`Counter] The amount of time worker threads were busy.
-- **[`injection_queue_depth`]**  
-  [`Gauge`] The number of tasks currently scheduled in the runtime's injection queue.
-- **[`total_local_queue_depth`]**  
-  [`Gauge`] The total number of tasks currently scheduled in workers' local queues.
-- **[`elapsed`]**  
-  [`Counter`] Total amount of time elapsed since observing runtime metrics.
-- **[`budget_forced_yield_count`]**  
-  [`Counter`] The number of times that a task was forced to yield because it exhausted its budget.
-- **[`io_driver_ready_count`]**  
-  [`Counter`] The number of ready events received from the I/O driver.
+- **[`workers_count`]** | type: Gauge  
+  The number of worker threads used by the runtime.
+- **[`total_park_count`]** | type: Counter  
+  The number of times worker threads parked.
+- **[`total_noop_count`]** | type: Counter  
+  The number of times worker threads unparked but performed no work before parking again.
+- **[`total_steal_count`]** | type: Counter  
+  The number of tasks worker threads stole from another worker thread.
+- **[`total_steal_operations`]** | type: Counter  
+  The number of times worker threads stole tasks from another worker thread.
+- **[`num_remote_schedules`]** | type: Counter  
+  The number of tasks scheduled from outside of the runtime.
+- **[`total_local_schedule_count`]** | type: Counter  
+  The number of tasks scheduled from worker threads.
+- **[`total_overflow_count`]** | type: Counter  
+  The number of times worker threads saturated their local queues.
+- **[`total_polls_count`]** | type: Counter  
+  The number of tasks that have been polled across all worker threads.
+- **[`total_busy_duration`]** | type: Counter  
+  The amount of time worker threads were busy.
+- **[`injection_queue_depth`]** | type: Gauge  
+  The number of tasks currently scheduled in the runtime's injection queue.
+- **[`total_local_queue_depth`]** | type: Gauge  
+  The total number of tasks currently scheduled in workers' local queues.
+- **[`elapsed`]** | type: Counter  
+  Total amount of time elapsed since observing runtime metrics.
+- **[`budget_forced_yield_count`]** | type: Counter  
+  The number of times that a task was forced to yield because it exhausted its budget.
+- **[`io_driver_ready_count`]** | type: Counter
+  The number of ready events received from the I/O driver.
 
 [`workers_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
 [`total_park_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
@@ -150,42 +150,42 @@ rustdocflags = ["--cfg", "tokio_unstable"]
 
 ## Task Metrics
 
-- **[`instrumented_count`]**  
-  [`Gauge`] The number of tasks instrumented in the interval.
-- **[`dropped_count`]**  
-  [`Gauge] The number of tasks dropped in the interval.
-- **[`first_poll_count`]**  
-  [`Gauge`] The number of tasks polled for the first time in the interval.
-- **[`total_first_poll_delay`]**  
-  [`Counter`] The total duration elapsed between the instant tasks are instrumented, and the instant they are first polled.
-- **[`total_idled_count`]**  
-  [`Counter`] The total number of times that tasks idled, waiting to be awoken.
-- **[`total_idle_duration`]**  
-  [`Counter`] The total duration that tasks idled.
-- **[`total_scheduled_count`]**  
-  [`Counter`] The total number of times that tasks were awoken (and then, presumably, scheduled for execution).
-- **[`total_scheduled_duration`]**  
-  [`Counter`] The total duration that tasks spent waiting to be polled after awakening.
-- **[`total_poll_count`]**  
-  [`Counter`] The total number of times that tasks were polled.
-- **[`total_poll_duration`]**  
-  [`Counter`] The total duration elapsed during polls.
-- **[`total_fast_poll_count`]**  
-  [`Counter`] The total number of times that polling tasks completed swiftly.
-- **[`total_fast_poll_duration`]**  
-  [`Counter`] The total duration of fast polls.
-- **[`total_slow_poll_count`]**  
-  [`Counter`] The total number of times that polling tasks completed slowly.
-- **[`total_slow_poll_duration`]**  
-  [`Counter`] The total duration of slow polls.
-- **[`total_short_delay_count`]**  
-  [`Counter`] The total count of short scheduling delays.
-- **[`total_short_delay_duration`]**  
-  [`Counter`] The total duration of short scheduling delays.
-- **[`total_long_delay_count`]**  
-  [`Counter`] The total count of long scheduling delays.
-- **[`total_long_delay_duration`]**  
-  [`Counter`] The total duration of long scheduling delays.
+- **[`instrumented_count`]** | type: Gauge  
+  The number of tasks instrumented in the interval.
+- **[`dropped_count`]** | type: Gauge
+  The number of tasks dropped in the interval.
+- **[`first_poll_count`]** | type: Gauge  
+  The number of tasks polled for the first time in the interval.
+- **[`total_first_poll_delay`]** | type: Counter
+  The total duration elapsed between the instant tasks are instrumented, and the instant they are first polled.
+- **[`total_idled_count`]** | type: Counter
+  The total number of times that tasks idled, waiting to be awoken.
+- **[`total_idle_duration`]** | type: Counter
+  The total duration that tasks idled.
+- **[`total_scheduled_count`]** | type: Counter
+  The total number of times that tasks were awoken (and then, presumably, scheduled for execution).
+- **[`total_scheduled_duration`]** | type: Counter
+  The total duration that tasks spent waiting to be polled after awakening.
+- **[`total_poll_count`]** | type: Counter
+  The total number of times that tasks were polled.
+- **[`total_poll_duration`]** | type: Counter
+  The total duration elapsed during polls.
+- **[`total_fast_poll_count`]** | type: Counter
+  The total number of times that polling tasks completed swiftly.
+- **[`total_fast_poll_duration`]** | type: Counter
+  The total duration of fast polls.
+- **[`total_slow_poll_count`]** | type: Counter
+  The total number of times that polling tasks completed slowly.
+- **[`total_slow_poll_duration`]** | type: Counter
+  The total duration of slow polls.
+- **[`total_short_delay_count`]** | type: Counter
+  The total count of short scheduling delays.
+- **[`total_short_delay_duration`]** | type: Counter
+  The total duration of short scheduling delays.
+- **[`total_long_delay_count`]** | type: Counter
+  The total count of long scheduling delays.
+- **[`total_long_delay_duration`]** | type: Counter
+  The total duration of long scheduling delays.
 
 [`instrumented_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
 [`dropped_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //!     // construct a TaskMonitor
 //!     let monitor = tokio_metrics_collector::TaskMonitor::new();
 //!     // add this monitor to task collector with label 'simple_task'
+//!     // please use unique labels for each monitor and
+//!     // instrument multiple tasks by the `instrument` function.
 //!     task_collector.add("simple_task", monitor.clone());
 //!
 //!     // spawn a background task and instrument

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -426,7 +426,8 @@ mod tests {
     async fn test_integrated_with_prometheus() {
         use prometheus::Encoder;
 
-        let tc = default_collector();
+        let tc = RuntimeCollector::default();
+
         prometheus::default_registry()
             .register(Box::new(tc))
             .unwrap();

--- a/src/task.rs
+++ b/src/task.rs
@@ -381,6 +381,7 @@ impl TaskCollector {
     }
 
     /// Add a [`TaskMonitor`] to collector.
+    /// If the label is already used by another monitor, an error will be thrown.
     pub fn add(&self, label: &str, monitor: TaskMonitor) -> Result<(), LabelAlreadyExists> {
         if self.producer.read().contains_key(label) {
             return Err(LabelAlreadyExists::new(label.into()));

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,19 +1,40 @@
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
+use std::error::Error;
+use std::fmt;
+
 use prometheus::{
     core::Desc,
     core::{Collector, Opts},
     proto, CounterVec, IntCounterVec, IntGaugeVec,
 };
 use std::collections::HashMap;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::Ordering;
 
 use tokio_metrics::TaskMetrics as TaskMetricsData;
 use tokio_metrics::TaskMonitor;
 
 const TASK_LABEL: &str = "task";
+#[allow(unused)]
 const METRICS_COUNT: usize = 18;
+
+#[derive(Debug)]
+pub struct LabelAlreadyExists {
+    label: String,
+}
+
+impl LabelAlreadyExists {
+    fn new(label: String) -> Self {
+        Self { label }
+    }
+}
+
+impl fmt::Display for LabelAlreadyExists {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "label '{}' already exists", self.label)
+    }
+}
+
+impl Error for LabelAlreadyExists {}
 
 // Reference: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html
 #[derive(Debug)]
@@ -36,10 +57,6 @@ struct TaskMetrics {
     total_long_delay_count: IntCounterVec,
     total_short_delay_duration: CounterVec,
     total_long_delay_duration: CounterVec,
-
-    _prev_instrumented_count: AtomicI64,
-    _prev_dropped_count: AtomicI64,
-    _prev_first_poll_count: AtomicI64,
 }
 
 impl TaskMetrics {
@@ -244,46 +261,40 @@ impl TaskMetrics {
             total_long_delay_count,
             total_short_delay_duration,
             total_long_delay_duration,
-
-            // private
-            _prev_instrumented_count: AtomicI64::default(),
-            _prev_dropped_count: AtomicI64::default(),
-            _prev_first_poll_count: AtomicI64::default(),
         }
     }
 
     fn update(&self, label: &str, data: TaskMetricsData) {
         macro_rules! update_counter {
             ( $field:ident,  "int" ) => {{
-                let past = self.$field.with_label_values(&[label]).get() as u64;
+                // let past = self.$field.with_label_values(&[label]).get() as u64;
+                // let new = data.$field as u64;
+                // debug_assert!(new >= past, "new: {new} >= past: {past}");
+                // self.$field
+                //     .with_label_values(&[label])
+                //     .inc_by(new.saturating_sub(past));
                 let new = data.$field as u64;
-                debug_assert!(new >= past, "new: {new} >= past: {past}");
-                self.$field
-                    .with_label_values(&[label])
-                    .inc_by(new.saturating_sub(past));
+                self.$field.with_label_values(&[label]).inc_by(new);
             }};
             ( $field:ident,  "duration" ) => {{
-                let past = self.$field.with_label_values(&[label]).get();
+                // let past = self.$field.with_label_values(&[label]).get();
+                // let new = data.$field.as_secs_f64();
+                // debug_assert!(new >= past, "new: {new} >= past: {past}");
+                // self.$field.with_label_values(&[label]).inc_by(new - past);
                 let new = data.$field.as_secs_f64();
-                debug_assert!(new >= past, "new: {new} >= past: {past}");
-                self.$field.with_label_values(&[label]).inc_by(new - past);
+                self.$field.with_label_values(&[label]).inc_by(new);
             }};
         }
 
-        macro_rules! update_gauge {
-            ( $field:ident, $prev_field:ident) => {{
-                let v = self.$prev_field.load(Ordering::Relaxed);
-                self.$field
-                    .with_label_values(&[label])
-                    .set(data.$field as i64 - v);
-                self.$prev_field
-                    .store(data.$field as i64, Ordering::Relaxed);
-            }};
-        }
-
-        update_gauge!(instrumented_count, _prev_instrumented_count);
-        update_gauge!(dropped_count, _prev_dropped_count);
-        update_gauge!(first_poll_count, _prev_first_poll_count);
+        self.instrumented_count
+            .with_label_values(&[label])
+            .set(data.instrumented_count as i64);
+        self.dropped_count
+            .with_label_values(&[label])
+            .set(data.dropped_count as i64);
+        self.first_poll_count
+            .with_label_values(&[label])
+            .set(data.first_poll_count as i64);
 
         update_counter!(total_first_poll_delay, "duration");
         update_counter!(total_idled_count, "int");
@@ -354,10 +365,10 @@ impl TaskMetrics {
 }
 
 /// TaskCollector
-#[derive(Debug)]
 pub struct TaskCollector {
     metrics: TaskMetrics,
-    producer: RwLock<HashMap<String, TaskMonitor>>,
+    producer:
+        RwLock<HashMap<String, Box<dyn Iterator<Item = tokio_metrics::TaskMetrics> + Send + Sync>>>,
 }
 
 impl TaskCollector {
@@ -370,11 +381,15 @@ impl TaskCollector {
     }
 
     /// Add a [`TaskMonitor`] to collector.
-    pub fn add(&self, label: &str, monitor: TaskMonitor) {
+    pub fn add(&self, label: &str, monitor: TaskMonitor) -> Result<(), LabelAlreadyExists> {
         if self.producer.read().contains_key(label) {
-            panic!("existed");
+            return Err(LabelAlreadyExists::new(label.into()));
         }
-        self.producer.write().insert(label.to_string(), monitor);
+        self.producer
+            .write()
+            .insert(label.to_string(), Box::new(monitor.intervals()));
+
+        Ok(())
     }
 
     /// Remove a [`TaskMonitor`] from collector.
@@ -383,8 +398,8 @@ impl TaskCollector {
     }
 
     fn get_metrics_data_by_label(&self, label: &str) -> TaskMetricsData {
-        let data = self.producer.read().get(label).unwrap().cumulative();
-        data
+        let data = self.producer.write().get_mut(label).unwrap().next();
+        data.unwrap()
     }
 }
 
@@ -469,12 +484,28 @@ mod tests {
         assert_eq!(descs[0].variable_labels.len(), 1);
     }
 
+    #[test]
+    fn test_task_collector_add() {
+        let monitor = tokio_metrics::TaskMonitor::new();
+        let tc = TaskCollector::new("");
+
+        let res = tc.add("custom", monitor.clone());
+        assert!(res.is_ok());
+
+        let res2 = tc.add("custom", monitor.clone());
+        assert!(res2.is_err());
+        assert_eq!(
+            format!("{}", res2.err().unwrap()),
+            "label 'custom' already exists".to_string()
+        );
+    }
+
     #[tokio::test]
     async fn test_runtime_collector_metrics() {
         let monitor = tokio_metrics::TaskMonitor::new();
         let tc = TaskCollector::new("");
 
-        tc.add("custom", monitor.clone());
+        tc.add("custom", monitor.clone()).unwrap();
 
         monitor.instrument(tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await
@@ -504,6 +535,7 @@ mod tests {
         );
         assert_eq!(metrics[0].get_metric().len(), 0);
     }
+
     #[tokio::test]
     async fn test_integrated_with_prometheus() {
         use prometheus::Encoder;
@@ -514,7 +546,7 @@ mod tests {
             .unwrap();
 
         let monitor = tokio_metrics::TaskMonitor::new();
-        tc.add("custom", monitor.clone());
+        tc.add("custom", monitor.clone()).unwrap();
 
         monitor.instrument(tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await

--- a/src/task.rs
+++ b/src/task.rs
@@ -267,34 +267,26 @@ impl TaskMetrics {
     fn update(&self, label: &str, data: TaskMetricsData) {
         macro_rules! update_counter {
             ( $field:ident,  "int" ) => {{
-                // let past = self.$field.with_label_values(&[label]).get() as u64;
-                // let new = data.$field as u64;
-                // debug_assert!(new >= past, "new: {new} >= past: {past}");
-                // self.$field
-                //     .with_label_values(&[label])
-                //     .inc_by(new.saturating_sub(past));
                 let new = data.$field as u64;
                 self.$field.with_label_values(&[label]).inc_by(new);
             }};
             ( $field:ident,  "duration" ) => {{
-                // let past = self.$field.with_label_values(&[label]).get();
-                // let new = data.$field.as_secs_f64();
-                // debug_assert!(new >= past, "new: {new} >= past: {past}");
-                // self.$field.with_label_values(&[label]).inc_by(new - past);
                 let new = data.$field.as_secs_f64();
                 self.$field.with_label_values(&[label]).inc_by(new);
             }};
         }
 
-        self.instrumented_count
-            .with_label_values(&[label])
-            .set(data.instrumented_count as i64);
-        self.dropped_count
-            .with_label_values(&[label])
-            .set(data.dropped_count as i64);
-        self.first_poll_count
-            .with_label_values(&[label])
-            .set(data.first_poll_count as i64);
+        macro_rules! update_gauge {
+            ( $field:ident) => {
+                self.$field
+                    .with_label_values(&[label])
+                    .set(data.$field as i64);
+            };
+        }
+
+        update_gauge!(instrumented_count);
+        update_gauge!(dropped_count);
+        update_gauge!(first_poll_count);
 
         update_counter!(total_first_poll_delay, "duration");
         update_counter!(total_idled_count, "int");

--- a/src/task.rs
+++ b/src/task.rs
@@ -540,13 +540,14 @@ mod tests {
     async fn test_integrated_with_prometheus() {
         use prometheus::Encoder;
 
-        let tc = default_collector();
-        prometheus::default_registry()
-            .register(Box::new(tc))
-            .unwrap();
+        let tc = TaskCollector::new("");
 
         let monitor = tokio_metrics::TaskMonitor::new();
         tc.add("custom", monitor.clone()).unwrap();
+
+        prometheus::default_registry()
+            .register(Box::new(tc))
+            .unwrap();
 
         monitor.instrument(tokio::spawn(async {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await


### PR DESCRIPTION
Resolve: https://github.com/Hanaasagi/tokio-metrics-collector/issues/4

1. If the label is already used by another monitor, return error.
2. Fix the logic of `tokio_task_instrumented_count` `tokio_task_dropped_count` and `tokio_task_first_poll_count`