### PR TITLE
Update Cargo.toml to fix "stats" feature issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rt = ["tokio"]
 [dependencies]
 lazy_static = "1.4.0"
 prometheus = "0.13.3"
-tokio-metrics = "0.3.0"
+tokio-metrics = "0.3.1"
 tokio = { version = "1.26.0", features = ["rt"], optional = true }
 parking_lot = "0.12.1"
 


### PR DESCRIPTION
Hi,

I've this error since tokio v1.33.0:

```bash
    Updating crates.io index
error: failed to select a version for `tokio`.
    ... required by package `tokio-metrics v0.2.2`
    ... which satisfies dependency `tokio-metrics = "^0.2.2"` of package `tokio-metrics-collector v0.2.0`
    ... which satisfies dependency `tokio-metrics-collector = "^0.2.0"` of package `pr0m3th3us v0.1.0 (/Users/j/www/lopez/pr0m3th3us)`
    ... which satisfies path dependency `pr0m3th3us` (locked to 0.1.0) of package `node v0.5.1 (/Users/j/www/lopez/node)`
versions that meet the requirements `^1.26.0` are: 1.32.0, 1.34.0, 1.33.0, 1.31.0, 1.30.0, 1.29.1, 1.29.0, 1.28.2, 1.28.1, 1.28.0, 1.27.0, 1.26.0

the package `tokio-metrics` depends on `tokio`, with features: `stats` but `tokio` does not have these features.


all possible versions conflict with previously selected packages.

  previously selected package `tokio v1.34.0`
    ... which satisfies dependency `tokio = "^1.34.0"` of package `node v0.5.1 (/Users/j/www/lopez/node)`

failed to select a version for `tokio` which could resolve this conflict
```

cf. https://github.com/tokio-rs/tokio-metrics/pull/55

This PR should fix the issue.