### PR TITLE
Use first_poll_count as counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ rustdocflags = ["--cfg", "tokio_unstable"]
   The total count of long scheduling delays.
 - **[`total_long_delay_duration`]** | type: Counter
   The total duration of long scheduling delays.
+- **[`tokio_task_total_first_poll_count`]** | type: Counter
+  The total number of tasks polled for the first time.
 
 [`instrumented_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
 [`dropped_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count

--- a/src/task.rs
+++ b/src/task.rs
@@ -41,7 +41,7 @@ impl Error for LabelAlreadyExists {}
 struct TaskMetrics {
     instrumented_count: IntGaugeVec,
     dropped_count: IntGaugeVec,
-    first_poll_count: IntCounterVec,
+    first_poll_count: IntGaugeVec,
     total_first_poll_delay: CounterVec,
     total_idled_count: IntCounterVec,
     total_idle_duration: CounterVec,
@@ -82,14 +82,15 @@ impl TaskMetrics {
         )
         .unwrap();
 
-        let first_poll_count = IntCounterVec::new(
+        let first_poll_count = IntGaugeVec::new(
             Opts::new(
                 "tokio_task_first_poll_count",
                 r#"The number of tasks polled for the first time."#,
             )
             .namespace(namespace.clone()),
             &[TASK_LABEL],
-        ).unwrap();
+        )
+        .unwrap();
 
         let total_first_poll_delay = CounterVec::new(
             Opts::new(
@@ -285,8 +286,8 @@ impl TaskMetrics {
 
         update_gauge!(instrumented_count);
         update_gauge!(dropped_count);
+        update_gauge!(first_poll_count);
 
-        update_counter!(first_poll_count, "int");
         update_counter!(total_first_poll_delay, "duration");
         update_counter!(total_idled_count, "int");
         update_counter!(total_idle_duration, "duration");
@@ -459,8 +460,6 @@ pub fn default_collector() -> &'static TaskCollector {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
 
     #[test]
@@ -514,57 +513,6 @@ mod tests {
         );
         assert_eq!(metrics[0].get_metric().len(), 1);
         assert_eq!(metrics[0].get_metric()[0].get_gauge().get_value(), 1.0);
-    }
-
-    #[tokio::test]
-    async fn test_task_first_poll_count() {
-        let monitor = tokio_metrics::TaskMonitor::new();
-        let tc = TaskCollector::new("");
-
-        tc.add("custom", monitor.clone()).unwrap();
-
-        let mut interval = monitor.intervals();
-        let mut next_interval = || interval.next().unwrap();
-
-        // no tasks have been constructed, instrumented, and polled at least once
-        assert_eq!(next_interval().first_poll_count, 0);
-
-        let task = monitor.instrument(async {});
-        let task2 = monitor.instrument(async {});
-
-        // `task` has been constructed and instrumented, but has not yet been polled
-        assert_eq!(next_interval().first_poll_count, 0);
-
-        // poll `task` to completion
-        task.await;
-        task2.await;
-        // `task` has been constructed, instrumented, and polled at least once
-        assert_eq!(next_interval().first_poll_count, 2);
-
-        // since the last interval was produced, 0 tasks have been constructed, instrumented and polled
-        assert_eq!(next_interval().first_poll_count, 0);
-
-        let metrics = tc.collect();
-        assert_eq!(metrics.len(), METRICS_COUNT);
-        assert_eq!(metrics[2].get_name(), "tokio_task_first_poll_count");
-        assert_eq!(
-            metrics[2].get_help(),
-            "The number of tasks polled for the first time.".to_string()
-        );
-        assert_eq!(metrics[2].get_metric().len(), 1);
-        assert_eq!(metrics[2].get_metric()[0].get_counter().get_value(), 2.0);
-
-        // check levels again
-        assert_eq!(next_interval().first_poll_count, 0);
-
-        assert_eq!(metrics.len(), METRICS_COUNT);
-        assert_eq!(metrics[2].get_name(), "tokio_task_first_poll_count");
-        assert_eq!(
-            metrics[2].get_help(),
-            "The number of tasks polled for the first time.".to_string()
-        );
-        assert_eq!(metrics[2].get_metric().len(), 1);
-        assert_eq!(metrics[2].get_metric()[0].get_counter().get_value(), 2.0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]


### PR DESCRIPTION
Hi! :wave:  I've noticed that the "current" state of `first_poll_count` as a gauge almost always equals to 0 in our production application.
What do you think about changing it to be a `counter` instead?

I'm following a [guide](https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_first_poll_delay) about debugging latency issues using tokio metrics and I'm not able to chart this specific derived value:

```rust
total_first_poll_delay ÷ first_poll_count.
```
